### PR TITLE
Add Live Migration Mixin

### DIFF
--- a/oswin_tempest_plugin/tests/_mixins/migrate.py
+++ b/oswin_tempest_plugin/tests/_mixins/migrate.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from tempest.common import waiters
 import testtools
 
 from oswin_tempest_plugin import config
@@ -42,4 +43,65 @@ class _MigrateMixin(object):
     def test_migration(self):
         server_tuple = self._create_server()
         self._migrate_server(server_tuple)
+        self._check_server_connectivity(server_tuple)
+
+
+class _LiveMigrateMixin(object):
+    """Live migration mixin.
+
+    This mixin will add a Live migration test. It will perform the
+    following operations:
+
+    * Spawn instance.
+    * Live migrate the instance.
+    * Check the server connectivity.
+    """
+
+    max_microversion = '2.24'
+
+    def _live_migrate_server(self, server_tuple, destination_host=None,
+                             state='ACTIVE', volume_backed=False):
+        kwargs = dict()
+        server = server_tuple.server
+        admin_server = self._get_server_as_admin(server)
+        current_host = admin_server['OS-EXT-SRV-ATTR:host']
+
+        block_migration = (CONF.compute_feature_enabled.
+                           block_migration_for_live_migration and
+                           not volume_backed)
+
+        kwargs['disk_over_commit'] = False
+
+        self.admin_servers_client.live_migrate_server(
+            server['id'],
+            host=destination_host,
+            block_migration=block_migration,
+            **kwargs)
+
+        waiters.wait_for_server_status(self.admin_servers_client, server['id'],
+                                       state)
+
+        admin_server = self._get_server_as_admin(server)
+        after_migration_host = admin_server['OS-EXT-SRV-ATTR:host']
+
+        migration_list = (self.admin_migrations_client.list_migrations()
+                          ['migrations'])
+
+        msg = ("Live Migration failed. Migrations list for Instance "
+               "%s: [" % server['id'])
+        for live_migration in migration_list:
+            if live_migration['instance_uuid'] == server['id']:
+                msg += "\n%s" % live_migration
+        msg += "]"
+
+        if destination_host:
+            self.assertEqual(destination_host, after_migration_host, msg)
+        else:
+            self.assertNotEqual(current_host, after_migration_host, msg)
+
+    @testtools.skipUnless(CONF.compute_feature_enabled.live_migration,
+                          'Live migration option enabled.')
+    def test_live_migration(self):
+        server_tuple = self._create_server()
+        self._live_migrate_server(server_tuple)
         self._check_server_connectivity(server_tuple)

--- a/oswin_tempest_plugin/tests/scenario/test_cluster.py
+++ b/oswin_tempest_plugin/tests/scenario/test_cluster.py
@@ -21,9 +21,9 @@ from tempest.lib import exceptions as lib_exc
 from oswin_tempest_plugin.clients import wsman
 from oswin_tempest_plugin import config
 from oswin_tempest_plugin import exceptions
-from oswin_tempest_plugin.tests import test_base
 from oswin_tempest_plugin.tests._mixins import migrate
 from oswin_tempest_plugin.tests._mixins import resize
+from oswin_tempest_plugin.tests import test_base
 
 CONF = config.CONF
 LOG = logging.getLogger(__name__)
@@ -31,6 +31,7 @@ LOG = logging.getLogger(__name__)
 
 class HyperVClusterTest(test_base.TestBase,
                         migrate._MigrateMixin,
+                        migrate._LiveMigrateMixin,
                         resize._ResizeMixin):
 
     """The test suite for the Hyper-V Cluster.
@@ -133,11 +134,6 @@ class HyperVClusterTest(test_base.TestBase,
             raise exceptions.NotFoundException(resource=hostname,
                                                res_type='hypervisor')
         return hypervisor[0]
-
-    def _get_server_as_admin(self, server):
-        # only admins have access to certain instance properties.
-        return self.admin_servers_client.show_server(
-            server['id'])['server']
 
     def _create_server(self):
         server_tuple = super(HyperVClusterTest, self)._create_server()

--- a/oswin_tempest_plugin/tests/scenario/test_vnuma.py
+++ b/oswin_tempest_plugin/tests/scenario/test_vnuma.py
@@ -21,6 +21,7 @@ from oswin_tempest_plugin.tests._mixins import resize
 
 class HyperVvNumaTestCase(test_base.TestBase,
                           migrate._MigrateMixin,
+                          migrate._LiveMigrateMixin,
                           optional_feature._OptionalFeatureMixin,
                           resize._ResizeMixin):
     """Hyper-V vNUMA test suite.

--- a/oswin_tempest_plugin/tests/test_base.py
+++ b/oswin_tempest_plugin/tests/test_base.py
@@ -185,6 +185,11 @@ class TestBase(tempest.test.BaseTestCase):
 
         return server_tuple
 
+    def _get_server_as_admin(self, server):
+        # only admins have access to certain instance properties.
+        return self.admin_servers_client.show_server(
+            server['id'])['server']
+
     def _create_security_group(self):
         sg_name = data_utils.rand_name(self.__class__.__name__)
         sg_desc = sg_name + " description"


### PR DESCRIPTION
Mixin does a live migration and checks if old host is different
from destination host.

Mixin is used in test_cluster.py and test_vnuma.py.